### PR TITLE
Implement Phase 4

### DIFF
--- a/docopt/_vendor/__init__.py
+++ b/docopt/_vendor/__init__.py
@@ -1,0 +1,3 @@
+"""Compatibility shims bundled with docopt-ng."""
+
+__all__ = ["typing", "pathlib"]

--- a/docopt/_vendor/pathlib.py
+++ b/docopt/_vendor/pathlib.py
@@ -1,0 +1,33 @@
+"""Minimal pathlib backport for old Python.
+
+This module provides a small subset of :mod:`pathlib` used in the test suite.
+It tries to import :mod:`pathlib` or :mod:`pathlib2` and falls back to a very
+small shim if neither is available.
+"""
+
+try:
+    from pathlib import Path  # type: ignore
+except Exception:  # pragma: no cover - old Python
+    try:
+        from pathlib2 import Path  # type: ignore
+    except Exception:
+        import os
+
+        class Path(str):
+            """Simplistic Path implementation for Python 3.2."""
+
+            def __new__(cls, *parts):
+                return str.__new__(cls, os.path.join(*parts))
+
+            # Basic properties used in tests
+            @property
+            def suffix(self):
+                return os.path.splitext(self)[1]
+
+            @property
+            def stem(self):
+                return os.path.splitext(os.path.basename(self))[0]
+
+            def open(self, mode="r", *args, **kwargs):
+                return open(self, mode, *args, **kwargs)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import json
 import re
-from pathlib import Path
+try:
+    from pathlib import Path  # type: ignore
+except Exception:  # pragma: no cover - old Python
+    try:
+        from pathlib2 import Path  # type: ignore
+    except Exception:
+        from docopt._vendor.pathlib import Path
 from typing import Generator
 from typing import Sequence
 from unittest import mock


### PR DESCRIPTION
## Summary
- vendor a tiny `pathlib` shim for old Python
- use conditional `Path` import in tests
- expose vendor modules via `__all__`

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843f425e0488326a3275067ffe64b05