### PR TITLE
Add setup.py and CI support for Python 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,21 +28,39 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.2", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up PDM for Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up PDM
+        if: matrix.python-version != '3.2'
         uses: pdm-project/setup-pdm@v2
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        if: matrix.python-version != '3.2'
         run: pdm sync -d -G dev
+
+      - name: Install legacy dependencies
+        if: matrix.python-version == '3.2'
+        run: |
+          pip install -U pip setuptools
+          pip install pytest pytest-cov
+          python setup.py install
 
       - name: Run tests
         run: |
-          pdm run -v pytest --cov-report term-missing --cov-report xml --cov=docopt --mypy
+          if [ "${{ matrix.python-version }}" = "3.2" ]; then
+            pytest --cov-report term-missing --cov-report xml --cov=docopt
+          else
+            pdm run -v pytest --cov-report term-missing --cov-report xml --cov=docopt --mypy
+          fi
 
       - name: Upload coverage
         uses: codecov/codecov-action@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     {name = "Nick Crews", email = "nicholas.b.crews@gmail.com"},
 ]
 dependencies = []
-requires-python = ">=3.7"
+requires-python = ">=3.2"
 license = {text = "MIT"}
 readme = "README.md"
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+from setuptools import setup, find_packages
+
+# Extract version without importing the package
+version = {}
+with open('docopt/_version.py') as f:
+    exec(f.read(), version)
+
+with open('README.md', 'r', encoding='utf-8') as fh:
+    long_description = fh.read()
+
+setup(
+    name='docopt-ng',
+    version=version['__version__'],
+    description='Jazzband-maintained fork of docopt, the humane command line arguments parser.',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author='Nick Crews',
+    author_email='nicholas.b.crews@gmail.com',
+    url='https://github.com/jazzband/docopt-ng',
+    license='MIT',
+    packages=find_packages(),
+    python_requires='>=3.2',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+    ],
+)


### PR DESCRIPTION
## Summary
- allow installing on Python 3.2 by shipping a legacy `setup.py`
- relax `requires-python` to `>=3.2`
- update CI to run tests on Python 3.2

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docopt')*

------
https://chatgpt.com/codex/tasks/task_b_6843f5010b1083269139c5b918f34241