### PR TITLE
Remove variable annotations for Python 3.2 compatibility

### DIFF
--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -179,7 +179,7 @@ class _LeafPattern(_Pattern):
         self, left: List["_LeafPattern"], collected: Optional[List["_Pattern"]] = None
     ) -> Tuple[bool, List["_LeafPattern"], List["_Pattern"]]:
         collected = [] if collected is None else collected
-        increment: Optional[Any] = None
+        increment = None
         pos, match = self.single_match(left)
         if match is None or pos is None:
             return False, left, collected
@@ -512,16 +512,16 @@ def _parse_shorts(
             )
         )
     left = token.lstrip("-")
-    parsed: List[_Pattern] = []
+    parsed = []
     while left != "":
         short, left = "-" + left[0], left[1:]
-        transformations: Dict[Optional[str], Callable[[str], str]] = {None: lambda x: x}
+        transformations = {None: lambda x: x}
         if more_magic:
             transformations["lowercase"] = lambda x: x.lower()
             transformations["uppercase"] = lambda x: x.upper()
         # try identity, lowercase, uppercase, iff such resolves uniquely
         # (ie if upper and lowercase are not both defined)
-        similar: List[_Option] = []
+        similar = []
         de_abbreviated = False
         for transform_name, transform in transformations.items():
             transformed = list(set([transform(o.short) for o in options if o.short]))
@@ -629,8 +629,8 @@ def _parse_pattern(source: str, options: List[_Option]) -> _Required:
 
 def _parse_expr(tokens: _Tokens, options: List[_Option]) -> List[_Pattern]:
     """expr ::= seq ( '|' seq )* ;"""
-    result: List[_Pattern] = []
-    seq_0: List[_Pattern] = _parse_seq(tokens, options)
+    result = []
+    seq_0 = _parse_seq(tokens, options)
     if tokens.current() != "|":
         return seq_0
     if len(seq_0) > 1:
@@ -649,7 +649,7 @@ def _parse_expr(tokens: _Tokens, options: List[_Option]) -> List[_Pattern]:
 
 def _parse_seq(tokens: _Tokens, options: List[_Option]) -> List[_Pattern]:
     """seq ::= ( atom [ '...' ] )* ;"""
-    result: List[_Pattern] = []
+    result = []
     while tokens.current() not in [None, "]", ")", "|"]:
         atom = _parse_atom(tokens, options)
         if tokens.current() == "...":
@@ -709,7 +709,7 @@ def _parse_argv(
         except ValueError:
             return False
 
-    parsed: List[_Pattern] = []
+    parsed = []
     current_token = tokens.current()
     while current_token is not None:
         if current_token == "--":

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -935,7 +935,7 @@ def test_issue_71_double_dash_is_not_a_valid_option_argument():
     assert exc.left == []
 
 
-option_examples: Sequence[tuple[str, Sequence[_Option]]] = [
+option_examples = [
     ("", []),
     ("Some content\nbefore the first option.", []),
     ("-f", [_Option("-f", None, 0, False)]),


### PR DESCRIPTION
## Summary
- remove variable annotations from `docopt.__init__`
- drop a variable annotation from `tests/test_docopt.py`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843fbab62fc8326bf99b187f3b9856f