### PR TITLE
Port _DocSections to older Python

### DIFF
--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -24,12 +24,12 @@ Contributors (roughly in chronological order):
 
 import re
 import sys
+from collections import namedtuple
 from ._vendor.typing import (
     Any,
     Callable,
     Dict,
     List,
-    NamedTuple,
     Optional,
     Tuple,
     Type,
@@ -730,11 +730,10 @@ def _parse_argv(
     return parsed
 
 
-class _DocSections(NamedTuple):
-    before_usage: str
-    usage_header: str
-    usage_body: str
-    after_usage: str
+_DocSections = namedtuple(
+    "_DocSections",
+    ["before_usage", "usage_header", "usage_body", "after_usage"],
+)
 
 
 def _parse_docstring_sections(docstring: str) -> _DocSections:


### PR DESCRIPTION
## Summary
- drop `NamedTuple` import and use `collections.namedtuple`
- implement `_DocSections` using `namedtuple`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843fe2beaf88326a7fbacd500c61574