### PR TITLE
Port to Python 3.2

### DIFF
--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -921,10 +921,9 @@ def docopt(
     sections = _parse_docstring_sections(docstring)
     _lint_docstring(sections)
     DocoptExit.usage = sections.usage_header + sections.usage_body
-    options = [
-        *_parse_options(sections.before_usage),
-        *_parse_options(sections.after_usage),
-    ]
+    options = []
+    options.extend(_parse_options(sections.before_usage))
+    options.extend(_parse_options(sections.after_usage))
     pattern = _parse_pattern(_formal_usage(sections.usage_body), options)
     pattern_options = set(pattern.flat(_Option))
     for options_shortcut in pattern.flat(_OptionsShortcut):

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import re
 from textwrap import dedent
 from typing import Sequence


### PR DESCRIPTION
## Summary
- remove unpacking syntax unsupported on Python 3.2
- drop `__future__` import from tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6844003f4a1c8326b46390d4e69abab5